### PR TITLE
Updated uglify-js dependency to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "integrity": "sha1-Zstrqqu2XeinHXk/XGX9GE83mLY=",
       "requires": {
         "std": "0.1.40",
-        "uglify-js": "2.3.0"
+        "uglify-js": "2.6.0"
       }
     },
     "source-map": {
@@ -43,7 +43,7 @@
       "integrity": "sha1-Nnil9lCU2eG2teJu2/wCErg0K3E="
     },
     "uglify-js": {
-      "version": "2.3.0",
+      "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.0.tgz",
       "integrity": "sha1-LN7BbTeKiituz7aYl4TPi3rlSR8=",
       "requires": {


### PR DESCRIPTION
Uglify on the package-lock.json file was an out of date version. Updated to 2.6.0.